### PR TITLE
Update YAML for White House form

### DIFF
--- a/whitehouse/WH000045.yml
+++ b/whitehouse/WH000045.yml
@@ -71,7 +71,7 @@ contact_form:
           - Dr.
       - name: Contact.MailingState
         selector: "#Contact\\.MailingState"
-        value: $ADDRESS_STATE
+        value: $ADDRESS_STATE_FULL
         required: true
         options:
           - Alabama


### PR DESCRIPTION
This is mostly working now, the only thing that is left to do is create a variable to fill in for the full state name. The form currently uses `$ADDRESS_STATE` but we could change this name to be clearer that it's the long-form version if wanted.