### PR TITLE
Update success text for CA state legislators

### DIFF
--- a/states/CA/lower.yaml
+++ b/states/CA/lower.yaml
@@ -44,4 +44,4 @@ contact_form:
           selector: "input[name=submitButton]"
   success:
     body:
-      contains: "Your message has been received."
+      contains: "you for contacting"

--- a/states/CA/upper.yaml
+++ b/states/CA/upper.yaml
@@ -44,4 +44,4 @@ contact_form:
           selector: "input[name=submitButton]"
   success:
     body:
-      contains: "Your message has been received."
+      contains: "you for contacting"


### PR DESCRIPTION
It seems as if different legislators have different success texts, but they seem to thank people for contacting them (though sometimes it's at the beginning of the sentence and sometimes in the middle). Thus, change to 'you for contacting' as the success text.