### PR TITLE
Attempt different success text for CA legislature

### DIFF
--- a/states/CA/lower.yaml
+++ b/states/CA/lower.yaml
@@ -44,4 +44,4 @@ contact_form:
           selector: "input[name=submitButton]"
   success:
     body:
-      contains: "you for contacting"
+      contains: "hank you"

--- a/states/CA/upper.yaml
+++ b/states/CA/upper.yaml
@@ -44,4 +44,4 @@ contact_form:
           selector: "input[name=submitButton]"
   success:
     body:
-      contains: "you for contacting"
+      contains: "hank you"


### PR DESCRIPTION
It seems as if "you for contacting" isn't broad enough for all forms, so try using "hank you" since every form seems to have "thank you" or "Thank you".