### PR TITLE
Use new selector attribute for CA legislature success

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,9 @@ Schema is based on [that of unitedstates/contact-congress](https://github.com/un
   format extension, which 2captcha requires. See `states/SC/upper.yaml`
   for an example.
 
-* In `success` section, instead of `body`, one can specify text that
-  must match an alert. See `states/WA/governor.yaml` for an example.
+* In a `success` section, instead of `body`, one can specify text that must match an alert, or one
+  can specify a CSS selector for an element that must be found. See `states/WA/governor.yaml` for
+  an example of the alert functionality, and `states/CA/lower.yaml` for an example of a CSS selector.
 
 * Introduction of meta variables, described below.
 

--- a/states/CA/lower.yaml
+++ b/states/CA/lower.yaml
@@ -43,5 +43,4 @@ contact_form:
         - value: Submit
           selector: "input[name=submitButton]"
   success:
-    body:
-      contains: "hank you"
+    selector: "input[value='Close Window']"

--- a/states/CA/upper.yaml
+++ b/states/CA/upper.yaml
@@ -43,5 +43,4 @@ contact_form:
         - value: Submit
           selector: "input[name=submitButton]"
   success:
-    body:
-      contains: "hank you"
+    selector: "input[value='Close Window']"


### PR DESCRIPTION
With the new selector attribute for the success section, we should now detect success properly for all CA legislators. Switch to using this attribute, and add information to the README about it.