### PR TITLE
Add a wait to Florida governor form config

### DIFF
--- a/states/FL/governor.yaml
+++ b/states/FL/governor.yaml
@@ -1,6 +1,8 @@
 contact_form:
   steps:
     - visit: "https://www.flgov.com/email-the-governor/"
+    - wait:
+        - value: 5
     - fill_in:
         - name: "your-name"
           selector: "input[name='your-name']"


### PR DESCRIPTION
The captcha image apparently takes a little bit to load, and trying to screenshot it beforehand results in an error since it's a broken image. Add a wait of 5 seconds to prevent this problem.