### PR TITLE
Use more direct URL for Ohio legislature form config

### DIFF
--- a/states/OH/lower.yaml
+++ b/states/OH/lower.yaml
@@ -1,8 +1,6 @@
 contact_form:
   steps:
-    - visit: "$META_OFFICIAL_URL"
-    - click_on:
-        - selector: "div.contactModule > div.data > a"
+    - visit: "$META_OFFICIAL_URL/contact"
     - fill_in:
         - name: tbxFirstName
           selector: "#tbxFirstName"

--- a/states/OH/upper.yaml
+++ b/states/OH/upper.yaml
@@ -1,8 +1,6 @@
 contact_form:
   steps:
-    - visit: "$META_OFFICIAL_URL"
-    - click_on:
-        - selector: "div.email > a"
+    - visit: "$META_OFFICIAL_URL/contact"
     - fill_in:
         - name: firstName
           selector: "input[name=firstName]"


### PR DESCRIPTION
We currently visit the URL of the legislator and then click their contact button which takes you to their URL plus `/contact`. Instead, we can instead go directly there from the beginning.