### PR TITLE
Add a wait to IA governor form config

### DIFF
--- a/states/IA/governor.yaml
+++ b/states/IA/governor.yaml
@@ -48,6 +48,9 @@ contact_form:
           selector: "#edit-submitted-message-message-subject"
           value: "Other"
           required: true
+    # To prevent being detected as spam
+    - wait:
+        - value: 5
     - click_on:
         - value: "Submit"
           selector: ".webform-submit"


### PR DESCRIPTION
It seems that the IA governor form uses a spam-detection technique of checking how long was spent between visiting the form and actual form submission. 5 seconds plus the additional time needed to fill out the form should be enough to not be detected as spam, so add a 5 second wait.