### PR TITLE
Update related agency selection for GA governor

### DIFF
--- a/states/GA/governor.yaml
+++ b/states/GA/governor.yaml
@@ -60,12 +60,11 @@ contact_form:
           selector: "#edit-submitted-please-provide-a-brief-description-about-your-request-concern"
           value: $MESSAGE
           required: true
-    # As there is no 'other' choice, here we are entering a random option via the choose directive.
     - choose:
         - name: "submitted[please_select_which_agency_your_request_relates_to]"
-          selector: "input[type='radio']"
-          value: $TOPIC
-          required: true
+          selector: "#edit-submitted-please-select-which-agency-your-request-relates-to"
+          value: "- None -"
+          required: false
           options:
             "Education": "1"
             "Healthcare": "2"


### PR DESCRIPTION
Seems as if the selector changed, so switch to using the id. This also is not a required field, so switch to selecting "- None -" as that'll be most likely more accurate.