### PR TITLE
Update NY Gov form for a prefix not available on the form select

### DIFF
--- a/states/NY/governor.yaml
+++ b/states/NY/governor.yaml
@@ -158,6 +158,9 @@ contact_form:
           selector: "#edit-submitted-message"
           value: "$MESSAGE"
           required: true
+    # In the case of the constituent's prefix being unavailable on the form option (Dr. is a good example), select the "blank", which the form will accept.
+    - javascript:
+        - value: "if ( document.getElementById('edit-submitted-salutation').value == '' ) { document.getElementById('edit-submitted-salutation').value = 'blank' } ;"
     - click_on:
         - value: "Submit"
           selector: "input[type='submit'][name='op']"


### PR DESCRIPTION
Fixes #149 

I tested this by forcing "Dr." as a the value for the prefix.  Predictably, an error is produced in the logs, but form_processor continues.  Then the new JS changes the value to blank before hitting the submit button, and the form is successful.

I also tested "Mr." and the JS does not change it to blank, which is expected behavior.