### PR TITLE
Update success text for New Jersey governor

### DIFF
--- a/states/NJ/governor.yaml
+++ b/states/NJ/governor.yaml
@@ -92,4 +92,4 @@ contact_form:
           selector: "input[name='Next']"
   success:
     body:
-      contains: Thank you for contacting me.
+      contains: "I appreciate your taking the time"


### PR DESCRIPTION
The success text for the New Jersey governor's contact form seems to have changed. Update to reflect the new text.