### PR TITLE
2019-05-09 - Add confirmation checkbox.

### DIFF
--- a/states/WI/governor.yaml
+++ b/states/WI/governor.yaml
@@ -56,6 +56,8 @@ contact_form:
     - wait:
         - value: 5
     # Confirmation screen.
+    - javascript:
+        - value: "document.querySelector('#hdn-f1d59b73-aee4-469a-9e8a-38efdaca963e').click()"
     - click_on:
         - name: next
           selector: "#nextButton"


### PR DESCRIPTION
The click_on directive doesn't work on this checkbox, but object.click() does.  

Fixes #168 