### PR TITLE
2019-07-01 - Remove reply question

### DIFF
--- a/states/CA/governor.yaml
+++ b/states/CA/governor.yaml
@@ -75,11 +75,6 @@ contact_form:
             "UC/CSU Issues/Concerns": "6096"
             "Water Issues/Concerns": "6127"
             "Veteran Issues/Concerns": "38188"
-    - check:
-        - name: "reply"
-          selector: "#reply"
-          value: "1"
-          required: true
     - click_on:
         - value: "Continue"
           selector: "input[name='Submit']"


### PR DESCRIPTION
CA Governor form had a "do you want a reply?" question on the first page.  Seems they are no longer interested, as that question is no longer present.  Form changes to reflect that.