### PR TITLE
2019-07-24 - Remove unnecessary recaptcha selector

### DIFF
--- a/states/LA/governor.yaml
+++ b/states/LA/governor.yaml
@@ -30,7 +30,6 @@ contact_form:
           required: false #Yes, really.
     - recaptcha:
         - value: true
-          recaptcha_selector: "#grecaptcha"
     - click_on:
         - value: "Submit"
           selector: "#btn-submit"


### PR DESCRIPTION
Either they changed the page, or it behaves differently because of our recent changes to recaptcha handling.  I'm kinda ruling out the latter because the element we previously looking for isn't present.  

Either way, removing the specific selector fixes it.  