### PR TITLE
2019-08-05 - Use zip5 for NJ Gov

### DIFF
--- a/states/NJ/governor.yaml
+++ b/states/NJ/governor.yaml
@@ -71,7 +71,7 @@ contact_form:
           required: true
         - name: "ZIP"
           selector: "#ZIP"
-          value: $ADDRESS_ZIP_PLUS_4
+          value: $ADDRESS_ZIP5
           required: true
         - name: "EMAIL"
           selector: "input[name='EMAIL']"


### PR DESCRIPTION
This is a quick update to use just the 5 digit zip instead of the zip and +4.  
The NJ gov from wants either 5 digits, or NNNNN-NNNN when the +4 is included.  We are concatenating all nine digits together, without a hyphen, and that causes a failure.  The 5 digit zip is sufficient. 

Additionally, it appears that we might expect to be using the NNNNN-NNNN format (with hyphen), but in reality we are not.  There are a few forms out there that use it, and since they are working at this point, I'm hesitant to change it.  If it ain't broke, don't fix it. 