### PR TITLE
2020-03-18 - Update NV Gov success criteria

### DIFF
--- a/states/NV/governor.yaml
+++ b/states/NV/governor.yaml
@@ -154,4 +154,4 @@ contact_form:
           selector: "#btn_submit"
   success:
     alert:
-      contains: "Thank You"
+      contains: "Thank"


### PR DESCRIPTION
The browser alert we are searching for to find the success criteria is showing the ascii code for the space between the two words.  I don't know why.  Trimmed down to just get a single word. 

"Thank%20You"


