### PR TITLE
2020-06-15 - Update MN Gov for additional recaptcha

### DIFF
--- a/states/MN/governor.yaml
+++ b/states/MN/governor.yaml
@@ -1,6 +1,11 @@
 contact_form:
   steps:
     - visit: "https://mn.gov/governor/contact/"
+    - recaptcha:
+        - value: true
+    - click_on:
+        - value: "Submit"
+          selector: "input[type='submit'][value='Submit']"
     - fill_in:
         - name: "prefix"
           selector: "#prefix"


### PR DESCRIPTION
MN Governor is redirecting to a recaptcha before even loading the form (which also has a recaptcha on it :eyeroll:).  A regular browser doesn't seem to catch the redirect, but we seem to be getting it consistently in Mercury.  We can watch it and see if we have any strange failures.